### PR TITLE
Transition to using a pad instead of stdscr 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # edi
+
 A simple text editor using python and curses. This is an experimental branch trying to transition from screens to pads
 
 Use of this software as a daily driver is not recomended; it's just a hobby project

--- a/edi.py
+++ b/edi.py
@@ -124,7 +124,7 @@ def main (stdscr):
             newy = cursory
         stdscr.move(newy, cursorx)
 
-    def down(): # TODO: OOB avoidance
+    def down(): # TODO: OOB avoidance (temp fix)
         if cursory != stdscr.getmaxyx()[0] - 1:
             newy = cursory + 1
         else:

--- a/edi.py
+++ b/edi.py
@@ -8,12 +8,26 @@ from curses import wrapper # wrapper to run ncurses with standard error handling
 #============================ Initialized values ============================#
 filename = ""
 files = os.listdir()
+# Pad boundaries 
+lines = 0 
+cols = 0
+# Scroll tracker 
+downscrolls = False  
+
 locale.setlocale(locale.LC_ALL, '')
 code = locale.getpreferredencoding()
 
 def main (stdscr):
     global files
     global filename
+    # Pad boundaries 
+    global lines
+    global cols 
+    lines = curses.LINES 
+    cols = curses.COLS
+    # Pad init
+    pad = curses.newpad(lines, cols)
+
     stdscr.leaveok(False) # Make it so the cursor coordinates are correct/generally work
     curses.set_tabsize(4)
     #stdscr.scrollok(True)
@@ -30,7 +44,7 @@ def main (stdscr):
             contents = f.readlines()
             f.close()
             for i in contents:
-                stdscr.addstr(i)
+                pad.addstr(i)
         else:
             create = open(filename, "w")
             create.close()
@@ -41,11 +55,11 @@ def main (stdscr):
         global filename
         contents = []
         newcontents = [] # Stores new contents list after RegEx
-        for y in range (stdscr.getmaxyx()[0]):
-            contents.append(str(stdscr.instr(y,0)))
+        for y in range (pad.getmaxyx()[0]):
+            contents.append(str(pad.instr(y,0)))
         # instr doesn't really work for more than one line and is quite impractical
-        stdscr.clear()
-        stdscr.refresh()
+        pad.clear()
+        pad.refresh(lines - (curses.LINES), cols - (curses.COLS), 0, 0, curses.LINES, curses.COLS) 
         curses.endwin()
 
         if filename == "": # Ask about the name of the file if the file isn't one that has been opened
@@ -96,44 +110,45 @@ def main (stdscr):
     # TODO: deleting past the current line
     def delete(): # Doesn't work with the default GNOME terminal
         if cursorx != 0: # preventing crash
-            stdscr.delch(cursory, cursorx - 1) # Delete the character that is one to the
+            pad.delch(cursory, cursorx - 1) # Delete the character that is one to the
 
     def back_delete():
-        if cursorx != 0: # preventing crash
-            stdscr.delch(cursory, cursorx) # Delete the character to the righ. This also
-            # moves the other characters on that line one closer to the cursor
+        pad.delch(cursory, cursorx) # Delete the character to the righ. This also
+        # moves the other characters on that line one closer to the cursor
 
     def left():
         if cursorx != 0:
             newx = cursorx - 1
         else:
             newx = cursorx
-        stdscr.move(cursory, newx)
+        pad.move(cursory, newx)
 
     def right(): # TODO: OOB avoidance // temporarily fixed
-        if cursorx != stdscr.getmaxyx()[1] - 1:
+        if cursorx != curses.COLS - 1:
             newx = cursorx + 1
         else:
             newx = cursorx
-        stdscr.move(cursory, newx)
+        pad.move(cursory, newx)
 
     def up():
         if cursory != 0:
             newy = cursory - 1
         else:
             newy = cursory
-        stdscr.move(newy, cursorx)
+        pad.move(newy + downscrolls, cursorx)
 
     def down(): # TODO: OOB avoidance (temp fix)
-        if cursory != stdscr.getmaxyx()[0] - 1:
+        #pad.addstr(str(cursory) + "og" + str(curses.LINES - 1))
+        if cursory != curses.LINES - 1:
             newy = cursory + 1
         else:
             newy = cursory
-        stdscr.move(newy, cursorx)
+        pad.move(newy, cursorx)
 
 #==================================== Editing ====================================#
     while True: #Text editor loop
-        stdscr.refresh() # Refresh the screen, so the commands that are being send to stdscr
+        global downscrolls
+        pad.refresh(lines - curses.LINES, cols - curses.COLS, 0, 0, curses.LINES, curses.COLS) # Refresh the screen, so the commands that are being send to stdscr
         # actually gets executed
         cursorlist = list(curses.getsyx()) # Gets the current cursor position. y first, x last
         cursorx = cursorlist[1]
@@ -146,6 +161,12 @@ def main (stdscr):
 
         if key == 266: # F2
             save_close() # Saves the file with the content to a user specified file.
+
+        if key == 267:
+            pass 
+
+        if key == 268:
+            pass 
 
         elif key == 263: # Backspace
         # Doesn't work with the default GNOME terminal //TODO make it universal
@@ -171,6 +192,6 @@ def main (stdscr):
             pass
 
         else:
-            stdscr.addstr(str(key)) # Add input to the screen
+            pad.addstr(str(key)) # Add input to the screen
 
 wrapper(main)

--- a/edi.py
+++ b/edi.py
@@ -12,12 +12,12 @@ files = os.listdir()
 lines = 0 
 cols = 0
 # Scroll tracker 
-downscrolls = False  
 
 locale.setlocale(locale.LC_ALL, '')
 code = locale.getpreferredencoding()
 
 def main (stdscr):
+    stdscr.refresh() 
     global files
     global filename
     # Pad boundaries 
@@ -135,7 +135,7 @@ def main (stdscr):
             newy = cursory - 1
         else:
             newy = cursory
-        pad.move(newy + downscrolls, cursorx)
+        pad.move(newy, cursorx)
 
     def down(): # TODO: OOB avoidance (temp fix)
         #pad.addstr(str(cursory) + "og" + str(curses.LINES - 1))
@@ -147,7 +147,6 @@ def main (stdscr):
 
 #==================================== Editing ====================================#
     while True: #Text editor loop
-        global downscrolls
         pad.refresh(lines - curses.LINES, cols - curses.COLS, 0, 0, curses.LINES, curses.COLS) # Refresh the screen, so the commands that are being send to stdscr
         # actually gets executed
         cursorlist = list(curses.getsyx()) # Gets the current cursor position. y first, x last


### PR DESCRIPTION
This update switches over to the usage of pads. This _may_ allow for scrolling in a file in the future, allowing the opening, editing and viewing of files that are larger than the terminal window. For now, we are back at original functionality